### PR TITLE
Apply directory attributes later in CopyDirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 output*.txt
 output*.parq
+
+test-qwalk-log-file.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-qumulo_api~=4.1
+qumulo_api~=5.1
 typing-extensions~=3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-qumulo_api~=5.1
+qumulo_api
 typing-extensions~=3.10

--- a/test-qwalk.py
+++ b/test-qwalk.py
@@ -19,7 +19,7 @@ from qtasks.ModeBitsChecker import ModeBitsChecker
 from qtasks.Search import Search
 from qtasks.SummarizeOwners import SummarizeOwners
 from qumulo.rest_client import RestClient
-from qwalk_worker import Creds, log_it, QWalkWorker
+from qwalk_worker import Creds, log_it, QWalkWorker, REST_PORT
 
 LOG_FILE_NAME = "test-qwalk-log-file.txt"
 
@@ -66,11 +66,17 @@ def main() -> None:
         print("-" * 80)
         sys.exit(0)
 
+    host = args.s
+    port = REST_PORT
+    if host.count(':') == 1:
+        host, port = host.split(':')
+        port = int(port)
+
     # Everything will happen in a new subdirectory.
     test_dir_name = "test-qwalk"
-    creds: Creds = {"QHOST": args.s, "QUSER": args.u, "QPASS": args.p}
+    creds: Creds = {"QHOST": host, "QPORT": port, "QUSER": args.u, "QPASS": args.p}
     log_it("Log in to: %s" % (args.s))
-    rc = RestClient(creds["QHOST"], 8000)
+    rc = RestClient(creds["QHOST"], creds["QPORT"])
     rc.login(creds["QUSER"], creds["QPASS"])
     parent_dir = "/"
     if args.d != "/":

--- a/test-qwalk.py
+++ b/test-qwalk.py
@@ -262,9 +262,7 @@ def main() -> None:
         "Delete directory: %s/%s"
         % (parent_dir if parent_dir != "/" else "", test_dir_name)
     )
-    rc.fs.delete_tree(id_=test_dir["id"])
-    rc.fs.delete_tree(path=parent_dir + "/test-qwalk-copy")
-    rc.fs.delete_tree(path=parent_dir + "/copy-from-snap")
+    rc.tree_delete.create_job(test_dir["id"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The previous approach applied directory attributes, including timestamps, immediately when the directory was being processed. If the directory didn't have any children or all the children had already been created, this would be correct. However, if more children come in after we apply the attributes, the modification timestamp will be updated automatically by the FS.

# API update
test-qwalk.py was using a deprecated and then removed tree delete API for cleanup.

# REST API port
This allows easier internal testing with virtual clusters

# Queue partial batches
Directory children must be processed before requeued directories; without this it was possible for a worker to hang on to a partial batch including children hoping for an empty queue or more entries to fill out the batch

# Preserve directory attributes
Requeue directory processing until all children have arrived

# Add a CopyDirectory test
Verify that copied trees are identical