### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 qumulo_api
+qumulo-api
 typing-extensions~=3.10


### PR DESCRIPTION
fix: add qumulo-api to requirements.txt

Corrects issue found after creating a conda environment based on requirements.txt. There were missing dependencies from the qumulo-api package. 

> python3 qwalk.py -s QUMULOSERVER -d /homes/jparmely -c Search --re "." --cols path,name,type,size
Traceback (most recent call last):
  File "/mnt/share/homes/jparmely/repos/qumulo-filesystem-walk/qwalk.py", line 7, in <module>
    from qwalk_worker import QTASKS, QWalkWorker
  File "/mnt/share/homes/jparmely/repos/qumulo-filesystem-walk/qwalk_worker.py", line 15, in <module>
    from qtasks import Task
  File "/mnt/share/homes/jparmely/repos/qumulo-filesystem-walk/qtasks/__init__.py", line 6, in <module>
    from qumulo.rest_client import RestClient
ModuleNotFoundError: No module named 'qumulo'