### PR TITLE
Add multiple features and fixes to qwalk.py

### DIFF
--- a/qwalk.py
+++ b/qwalk.py
@@ -23,6 +23,7 @@ def main() -> None:
     parser.add_argument("-d", help="Starting directory", required=True)
     parser.add_argument("-g", help="Run with filesystem changes", action="store_true")
     parser.add_argument("-l", help="Log file. Use 'None' to disable logging.", default=datetime.datetime.now().strftime("%Y%m%dT%H%M%S-") + "output-walk-log.txt")
+    parser.add_argument("-f", help="Force script to run on directly on a Qumulo node.", action="store_true")
     parser.add_argument(
         "-c",
         help="Class to run.",
@@ -39,6 +40,13 @@ def main() -> None:
         parser.print_help()
         print("-" * 80)
         sys.exit(0)
+
+    # Make sure we're not running directly on a Qumulo node
+    RunningOnNode=os.system("qq cluster_conf | jq -cr .cluster_name > " + os.devnull + " 2>&1 ")
+    if RunningOnNode == 0:
+        print("The qwalk command should not be executed direcly on a Qumulo node.")
+        if not args.f:
+            exit(1)
 
     # Prompt for password if one was not given by ENV or command entry
     if not args.p:

--- a/qwalk.py
+++ b/qwalk.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import argparse
+import datetime
 import os
 import sys
 
@@ -20,7 +21,7 @@ def main() -> None:
     )
     parser.add_argument("-d", help="Starting directory", required=True)
     parser.add_argument("-g", help="Run with filesystem changes", action="store_true")
-    parser.add_argument("-l", help="Log file", default="output-walk-log.txt")
+    parser.add_argument("-l", help="Log file. Use 'None' to disable logging.", default=datetime.datetime.now().strftime("%Y%m%dT%H%M%S-") + "output-walk-log.txt")
     parser.add_argument(
         "-c",
         help="Class to run.",
@@ -37,6 +38,10 @@ def main() -> None:
         parser.print_help()
         print("-" * 80)
         sys.exit(0)
+
+    # If the log parameter is set to "None" send logs to devNull
+    if args.l == "None":
+        args.l == os.devnull
 
     QWalkWorker.run_all(
         args.s,

--- a/qwalk.py
+++ b/qwalk.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import argparse
 import datetime
+import getpass
 import os
 import sys
 
@@ -17,7 +18,7 @@ def main() -> None:
         "-u", help="Qumulo API user", default=os.getenv("QUSER") or "admin"
     )
     parser.add_argument(
-        "-p", help="Qumulo API password", default=os.getenv("QPASS") or "admin"
+        "-p", help="Qumulo API password", default=os.getenv("QPASS")
     )
     parser.add_argument("-d", help="Starting directory", required=True)
     parser.add_argument("-g", help="Run with filesystem changes", action="store_true")
@@ -38,6 +39,10 @@ def main() -> None:
         parser.print_help()
         print("-" * 80)
         sys.exit(0)
+
+    # Prompt for password if one was not given by ENV or command entry
+    if not args.p:
+        args.p = getpass.getpass()
 
     # If the log parameter is set to "None" send logs to devNull
     if args.l == "None":


### PR DESCRIPTION
Logging:
- Added unique log file naming by default.
- Added a "None" option for the logging parameter (-l) that will direct logging to devNull (cross-platform).

Passwords
- Added option to securely provide the password via getpass and removed the default of 'admin' from the password parameter (-p).

Foot-Gun Prevention
- Added a check and override parameter (-f) for preventing the script from running directly on a Qumulo node.