### PR TITLE
Fixing type error in Search.py

### DIFF
--- a/qtasks/Search.py
+++ b/qtasks/Search.py
@@ -67,7 +67,7 @@ class Search:
                     line = "|".join(
                         [
                             # mypy insists "TypedDict key must be a string literal"
-                            file_obj[col] if col in file_obj else col  # type: ignore[misc]
+                            str(file_obj[col]) if col in file_obj else col  # type: ignore[misc]
                             for col in self.cols
                         ]
                     )


### PR DESCRIPTION
some columns are not strings, and the `join` command fails if trying to query those columns. Cast the fields to string before making the `join`