### PR TITLE
Prevent treadmilling in CopyDirectory

### DIFF
--- a/qtasks/ApplyAcls.py
+++ b/qtasks/ApplyAcls.py
@@ -79,6 +79,10 @@ class ApplyAcls:
                 work_obj.action_count.value += action_count
 
     @staticmethod
+    def minimum_queue_length() -> int:
+        return 10
+
+    @staticmethod
     def work_start(work_obj: Worker) -> None:
         if os.path.exists(work_obj.LOG_FILE_NAME):
             os.remove(work_obj.LOG_FILE_NAME)

--- a/qtasks/ChangeExtension.py
+++ b/qtasks/ChangeExtension.py
@@ -44,6 +44,10 @@ class ChangeExtension:
                 work_obj.action_count.value += len(results)
 
     @staticmethod
+    def minimum_queue_length() -> int:
+        return 10
+
+    @staticmethod
     def work_start(work_obj: Worker) -> None:
         if os.path.exists(work_obj.LOG_FILE_NAME):
             os.remove(work_obj.LOG_FILE_NAME)

--- a/qtasks/CopyDirectory.py
+++ b/qtasks/CopyDirectory.py
@@ -308,6 +308,10 @@ class CopyDirectory:
             work_obj.add_to_queue({"type": "process_list", "list": requeue})
 
     @staticmethod
+    def minimum_queue_length() -> int:
+        return 100000
+
+    @staticmethod
     def work_start(work_obj: Worker) -> None:
         if os.path.exists(work_obj.LOG_FILE_NAME):
             os.remove(work_obj.LOG_FILE_NAME)

--- a/qtasks/DataReductionTest.py
+++ b/qtasks/DataReductionTest.py
@@ -113,6 +113,10 @@ class DataReductionTest:
             work_obj.action_count.value += action_count
 
     @staticmethod
+    def minimum_queue_length() -> int:
+        return 10
+
+    @staticmethod
     def work_start(_work_obj: Worker) -> None:
         if os.path.exists(DataReductionTest.FILE_NAME):
             os.remove(DataReductionTest.FILE_NAME)

--- a/qtasks/ModeBitsChecker.py
+++ b/qtasks/ModeBitsChecker.py
@@ -30,6 +30,10 @@ class ModeBitsChecker:
             work_obj.action_count.value += action_count
 
     @staticmethod
+    def minimum_queue_length() -> int:
+        return 10
+
+    @staticmethod
     def work_start(_work_obj: Worker) -> None:
         if os.path.exists(ModeBitsChecker.FILE_NAME):
             os.remove(ModeBitsChecker.FILE_NAME)

--- a/qtasks/Search.py
+++ b/qtasks/Search.py
@@ -81,6 +81,10 @@ class Search:
                 work_obj.action_count.value += len(results)
 
     @staticmethod
+    def minimum_queue_length() -> int:
+        return 10
+
+    @staticmethod
     def work_start(work_obj: Worker) -> None:
         if os.path.exists(work_obj.LOG_FILE_NAME):
             os.remove(work_obj.LOG_FILE_NAME)

--- a/qtasks/SummarizeOwners.py
+++ b/qtasks/SummarizeOwners.py
@@ -76,6 +76,10 @@ class SummarizeOwners:
         print("-" * 80)
 
     @staticmethod
+    def minimum_queue_length() -> int:
+        return 10
+
+    @staticmethod
     def work_start(_work_obj: Worker) -> None:
         if os.path.exists(SummarizeOwners.FILE_NAME):
             os.remove(SummarizeOwners.FILE_NAME)

--- a/qtasks/__init__.py
+++ b/qtasks/__init__.py
@@ -54,6 +54,10 @@ class Task(Protocol):  # pylint: disable=super-init-not-called
         ...
 
     @staticmethod
+    def minimum_queue_length() -> int:
+        ...
+
+    @staticmethod
     def work_start(_work_obj: Worker) -> None:
         ...
 


### PR DESCRIPTION
Internal testing showed that https://github.com/Qumulo/qumulo-filesystem-walk/pull/8 made it possible or at least much more likely for CopyDirectory to get stuck in a loop waiting for files to be created under a directory before the directory attributes were applied when MAX_QUEUE_LEN is small.

This happened because CopyDirectory re-queues directories for processing when it detects that not all of the required children are present. Adding new children modifies the directory attributes, so we want to apply attributes _after_ all the children are present. If creating a required missing child is deferred into `new-queue.txt`, CopyDirectory will treadmill. Having a very high MAX_QUEUE_LEN (ie the same value as before #8) makes this very unlikely.

So this restores the old behavior max queue length but only for CopyDirectory. The queue elements for CopyDirectory are just `int`'s, so very small and not going to cause much memory pressure. Not a perfect fix, but straight forward until something better can be figured out.